### PR TITLE
Fix Connect hanging on "Connecting…" (stdin never closed)

### DIFF
--- a/Panel.qml
+++ b/Panel.qml
@@ -673,11 +673,12 @@ Panel {
     busy = true
     lastError = ""
     pendingAction = args[0] || ""
+    // Close stdin after the URL is written. Python's connect --stdin does
+    // stdin.read() until EOF; leaving the pipe open hangs on "Connecting…".
+    syncProc.queuedStdin = stdinData ? (String(stdinData) + "\n") : ""
+    syncProc.stdinEnabled = !!stdinData
     syncProc.command = ["python3", "-u", root.scriptPath].concat(args)
     syncProc.running = true
-    if (stdinData) {
-      syncProc.write(String(stdinData) + "\n")
-    }
   }
 
   function handleOutput(text) {
@@ -744,7 +745,15 @@ Panel {
 
   Process {
     id: syncProc
-    stdinEnabled: true
+    property string queuedStdin: ""
+    stdinEnabled: false
+    onStarted: {
+      if (queuedStdin) {
+        write(queuedStdin)
+        queuedStdin = ""
+        stdinEnabled = false
+      }
+    }
     stdout: StdioCollector {
       waitForEnd: true
       onStreamFinished: {

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "id": "gladimdim.config-sync",
   "name": "Omarchy Config Sync",
-  "version": "1.2.19",
+  "version": "1.2.20",
   "author": "Dmytro Gladkyi",
   "license": "MIT",
   "description": "Seamlessly sync all your Omarchy configurations, shortcuts, themes, and plugins between your machines.",

--- a/scripts/config_sync.py
+++ b/scripts/config_sync.py
@@ -62,7 +62,7 @@ SKIP_DIR_NAMES = {".git", "__pycache__", ".mypy_cache", ".pytest_cache", "node_m
 SKIP_FILE_NAMES = {".DS_Store"}
 SKIP_NAME_RE = re.compile(r"\.bak(\.|$)")
 PROTECTED_PLUGINS = {PLUGIN_ID}  # this plugin is excluded from sync so it does not self-report or overwrite itself
-PLUGIN_VERSION = "1.2.19"
+PLUGIN_VERSION = "1.2.20"
 
 FILE_SUMMARIES = {
     "hypr/autostart.lua": "Autostart programs",
@@ -2641,7 +2641,7 @@ def cmd_snapshot(ctx: Context, args: argparse.Namespace) -> dict[str, Any]:
 def cmd_connect(ctx: Context, args: argparse.Namespace) -> dict[str, Any]:
     source_raw = ""
     if getattr(args, "stdin", False):
-        source_raw = sys.stdin.read(MAX_URL_INPUT_BYTES).strip()
+        source_raw = sys.stdin.readline(MAX_URL_INPUT_BYTES).strip()
     if not source_raw:
         source_raw = " ".join(args.args).strip() or (args.url or "")
     kind, value = normalize_source(source_raw)
@@ -3557,7 +3557,7 @@ def cmd_set_url(ctx: Context, args: argparse.Namespace) -> dict[str, Any]:
     repo = configured_repo(ctx)
     source_raw = ""
     if getattr(args, "stdin", False):
-        source_raw = sys.stdin.read(MAX_URL_INPUT_BYTES).strip()
+        source_raw = sys.stdin.readline(MAX_URL_INPUT_BYTES).strip()
     if not source_raw:
         source_raw = " ".join(args.args).strip() or (args.url or "")
     kind, value = normalize_source(source_raw)

--- a/tests/test_config_sync.py
+++ b/tests/test_config_sync.py
@@ -798,6 +798,7 @@ def argparse_ns(**kwargs):
         delete_clone = False
         side = None
         url = None
+        stdin = False
         all = False
         dry_run = True
         args = []
@@ -1134,6 +1135,52 @@ class SecurityHardeningTests(unittest.TestCase):
         clean_ssh, cred_ssh = cs.prepare_git_credentials(ctx, ssh_url)
         self.assertEqual(clean_ssh, ssh_url)
         self.assertIsNone(cred_ssh)
+
+    def test_connect_stdin_uses_first_line_only(self) -> None:
+        # Quickshell writes URL + newline and leaves stdin open. read(64KiB)
+        # would consume extra bytes (or hang on a pipe); readline stops at \n.
+        ctx = self._ctx()
+        origin = self.tmp / "origin"
+        init_repo(origin)
+        write(origin / "README.md", "seed\n")
+        commit_all(origin, "init")
+        buf = io.StringIO(str(origin) + "\nthis-second-line-must-be-ignored\n")
+        with patch("sys.stdin", buf):
+            snap = cs.cmd_connect(ctx, argparse_ns(stdin=True, args=[], url=None))
+        self.assertTrue(snap["ok"], snap)
+        self.assertTrue(snap.get("connected") or snap["status"]["configured"])
+        self.assertEqual(buf.tell(), len(str(origin)) + 1)
+
+    def test_connect_stdin_does_not_wait_for_eof(self) -> None:
+        # Reproduce the bar hang: write one line, keep the pipe open.
+        with TempHome() as env:
+            origin = env.home / "origin"
+            init_repo(origin)
+            write(origin / "README.md", "seed\n")
+            commit_all(origin, "init")
+            child_env = os.environ.copy()
+            child_env["HOME"] = str(env.home)
+            child_env["XDG_DATA_HOME"] = str(env.data)
+            proc = subprocess.Popen(
+                [sys.executable, "-u", str(SCRIPTS / "config_sync.py"), "connect", "--stdin"],
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                env=child_env,
+            )
+            assert proc.stdin is not None
+            proc.stdin.write(str(origin) + "\n")
+            proc.stdin.flush()
+            try:
+                out, err = proc.communicate(timeout=8)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+                proc.communicate()
+                self.fail("connect --stdin hung waiting for EOF after one line")
+            self.assertEqual(proc.returncode, 0, err)
+            data = json.loads(out)
+            self.assertTrue(data.get("ok"), data)
 
     def test_cmd_connect_never_passes_credentials_as_argv(self) -> None:
         ctx = self._ctx()


### PR DESCRIPTION
## Problem

On a fresh Omarchy machine, pasting a git URL and clicking **Connect** left the panel on **Connecting…** indefinitely. GitHub auth was fine (`git ls-remote` succeeded); the helper was blocked on stdin.

`Panel.qml` starts `python3 … connect --stdin`, writes the URL plus a newline, and never closes the write end. The helper did `sys.stdin.read(64 * 1024)`, which waits for 64KiB **or EOF**. With ~50 bytes in an open pipe, that wait never ends.

## Fix

- Python: `sys.stdin.readline(MAX_URL_INPUT_BYTES)` for `connect` and `set-url`, so a newline is enough.
- QML: write the URL on `Process.onStarted`, then set `stdinEnabled = false` to close the write channel (EOF).

## Tests

- `test_connect_stdin_uses_first_line_only` — extra bytes after the first newline are ignored.
- `test_connect_stdin_does_not_wait_for_eof` — write one line, leave the pipe open, assert the helper returns instead of hanging.

`python3 -m unittest tests.test_config_sync` — new tests pass. `test_run_bounded_kills_child_exceeding_disk_budget` fails on current `main` in this environment as well (child writes ~30MB before kill); not part of this change.